### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Version: 0.0.0.9003
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),
-    person("Rebecca", "Fisher", , "R.Fisher@aims.gov.au", role = "aut"),
+    person("Rebecca", "Fisher", , "R.Fisher@aims.gov.au", role = "aut",
+           comment = c(ORCID = "0000-0001-5148-6731")),
     person("Ayla", "Pearson", , role = "ctb",
            comment = c(ORCID = "0000-0001-7388-1222"))
   )


### PR DESCRIPTION
Add Rebecca Fisher's ORCID (0000-0001-5148-6731).

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)